### PR TITLE
feat: add JSON schemas

### DIFF
--- a/src/schemas/token.schema.json
+++ b/src/schemas/token.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "src/schemas/token.schema.json",
+  "type": "object",
+  "description": "Metadata for a single token in a token list",
+  "additionalProperties": false,
+  "examples": [
+    {
+      "address": "0x1654653399040a61",
+      "contractName": "FlowToken",
+      "path": {
+        "vault": "/storage/flowTokenVault",
+        "balance": "/public/flowTokenBalance",
+        "receiver": "/public/flowTokenReceiver"
+      },
+      "symbol": "FLOW",
+      "name": "Flow",
+      "decimals": 8,
+      "logoURI": "https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/FLOW/logo.svg",
+      "tags": ["utility-token"],
+      "extensions": {
+        "website": "https://www.onflow.org",
+        "twitter": "https://twitter.com/flow_blockchain",
+        "discord": "http://discord.gg/flow"
+      }
+    }
+  ],
+  "definitions": {
+    "TagIdentifier": {
+      "type": "string",
+      "description": "The unique identifier of a tag",
+      "minLength": 1,
+      "maxLength": 20,
+      "pattern": "^[\\-\\w]+$",
+      "examples": ["compound", "stablecoin"]
+    }
+  },
+  "properties": {
+    "address": {
+      "description": "The contract address",
+      "examples": ["0x1654653399040a61"],
+      "pattern": "^0x[0-9a-fA-F]{16}$",
+      "type": "string"
+    },
+    "contractName": {
+      "description": "The name of the token contract",
+      "examples": ["FlowToken"],
+      "minLength": 1,
+      "maxLength": 20,
+      "pattern": "^[a-zA-Z0-9+\\-%/$.]+$",
+      "type": "string"
+    },
+    "path": {
+      "type": "object",
+      "description": "The paths of the vault",
+      "examples": [
+        {
+          "vault": "/storage/flowTokenVault",
+          "balance": "/public/flowTokenBalance",
+          "receiver": "/public/flowTokenReceiver"
+        }
+      ],
+      "required": ["vault", "balance", "receiver"],
+      "properties": {
+        "vault": {
+          "type": "string",
+          "description": "The path of Provider",
+          "pattern": "^/storage/[a-zA-Z0-9+\\-%/$.]+$",
+          "examples": ["/storage/flowTokenVault"]
+        },
+        "balance": {
+          "type": "string",
+          "description": "The path of Balance",
+          "pattern": "^/public/[a-zA-Z0-9+\\-%/$.]+$",
+          "examples": ["/public/flowTokenBalance"]
+        },
+        "receiver": {
+          "type": "string",
+          "description": "The path of Receiver",
+          "pattern": "^/public/[a-zA-Z0-9+\\-%/$.]+$",
+          "examples": ["/public/flowTokenReceiver"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "symbol": {
+      "type": "string",
+      "description": "The symbol for the token; must be alphanumeric",
+      "pattern": "^[a-zA-Z0-9+\\-%/$.]+$",
+      "minLength": 1,
+      "maxLength": 20,
+      "examples": ["FLOW"]
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the token",
+      "minLength": 1,
+      "maxLength": 40,
+      "pattern": "^[ \\w.'+\\-%/À-ÖØ-öø-ÿ:&\\[\\]\\(\\)]+$",
+      "examples": ["Flow"]
+    },
+    "decimals": {
+      "type": "integer",
+      "description": "The number of decimals for the token balance",
+      "minimum": 0,
+      "maximum": 255,
+      "examples": [8]
+    },
+    "logoURI": {
+      "type": "string",
+      "description": "A URI to the token logo asset; if not set, interface will attempt to find a logo based on the token address; suggest SVG or PNG of size 64x64",
+      "format": "uri",
+      "examples": [
+        "https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/FLOW/logo.svg"
+      ]
+    },
+    "tags": {
+      "type": "array",
+      "description": "An array of tag identifiers associated with the token; tags are defined at the list level",
+      "items": {
+        "$ref": "#/definitions/TagIdentifier"
+      },
+      "maxItems": 10,
+      "examples": ["stablecoin", "compound"]
+    },
+    "extensions": {
+      "type": "object",
+      "properties": {
+        "website": {
+          "type": "string",
+          "format": "uri"
+        },
+        "twitter": {
+          "type": "string",
+          "format": "uri"
+        },
+        "discord": {
+          "type": "string",
+          "format": "uri"
+        },
+        "explorer": {
+          "type": "string",
+          "format": "uri"
+        },
+        "github": {
+          "type": "string",
+          "format": "uri"
+        },
+        "medium": {
+          "type": "string",
+          "format": "uri"
+        },
+        "tgann": {
+          "type": "string",
+          "format": "uri"
+        },
+        "tggroup": {
+          "type": "string",
+          "format": "uri"
+        },
+        "coingeckoId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20,
+          "pattern": "^[\\-\\w]+$"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  "required": ["address", "contractName", "path", "symbol", "name", "decimals"]
+}

--- a/src/schemas/token.schema.json
+++ b/src/schemas/token.schema.json
@@ -158,6 +158,21 @@
           "type": "string",
           "format": "uri"
         },
+        "address": {
+          "type": "string"
+        },
+        "bridgeContract": {
+          "type": "string"
+        },
+        "assetContract": {
+          "type": "string"
+        },
+        "imageUrl": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
         "coingeckoId": {
           "type": "string",
           "minLength": 1,

--- a/src/schemas/tokenlist.schema.json
+++ b/src/schemas/tokenlist.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "src/schemas/tokenlist",
+  "title": "Flow Token List Schema",
+  "description": "Schema for lists of Flow fungible tokens",
+  "definitions": {
+    "Version": {
+      "type": "object",
+      "description": "The version of the list, used in change detection",
+      "examples": [
+        {
+          "major": 1,
+          "minor": 0,
+          "patch": 0
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "major": {
+          "type": "integer",
+          "description": "The major version of the list. Must be incremented when tokens are removed from the list or token addresses are changed.",
+          "minimum": 0,
+          "examples": [1, 2]
+        },
+        "minor": {
+          "type": "integer",
+          "description": "The minor version of the list. Must be incremented when tokens are added to the list.",
+          "minimum": 0,
+          "examples": [0, 1]
+        },
+        "patch": {
+          "type": "integer",
+          "description": "The patch version of the list. Must be incremented for any changes to the list.",
+          "minimum": 0,
+          "examples": [0, 1]
+        }
+      },
+      "required": ["major", "minor", "patch"]
+    },
+    "TagIdentifier": {
+      "type": "string",
+      "description": "The unique identifier of a tag",
+      "minLength": 1,
+      "maxLength": 20,
+      "pattern": "^[\\-\\w]+$",
+      "examples": ["compound", "stablecoin"]
+    },
+    "TagDefinition": {
+      "type": "object",
+      "description": "Definition of a tag that can be associated with a token via its identifier",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the tag",
+          "pattern": "^[ \\-\\w]+$",
+          "minLength": 1,
+          "maxLength": 20
+        },
+        "description": {
+          "type": "string",
+          "description": "A user-friendly description of the tag",
+          "pattern": "^[ \\-\\w\\.,:]+$",
+          "minLength": 1,
+          "maxLength": 200
+        }
+      },
+      "required": ["name", "description"],
+      "examples": [
+        {
+          "name": "Stablecoin",
+          "description": "A token with value pegged to another asset"
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the token list",
+      "minLength": 1,
+      "maxLength": 20,
+      "pattern": "^[\\w ]+$",
+      "examples": ["My Token List"]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The timestamp of this list version; i.e. when this immutable version of the list was created"
+    },
+    "version": {
+      "$ref": "#/definitions/Version"
+    },
+    "tokens": {
+      "type": "array",
+      "description": "The list of tokens included in the list",
+      "items": {
+        "$ref": "token.schema.json"
+      },
+      "minItems": 1,
+      "maxItems": 10000
+    },
+    "keywords": {
+      "type": "array",
+      "description": "Keywords associated with the contents of the list; may be used in list discoverability",
+      "items": {
+        "type": "string",
+        "description": "A keyword to describe the contents of the list",
+        "minLength": 1,
+        "maxLength": 20,
+        "pattern": "^[\\w ]+$",
+        "examples": ["compound", "lending", "personal tokens"]
+      },
+      "maxItems": 20,
+      "uniqueItems": true
+    },
+    "tags": {
+      "type": "object",
+      "description": "A mapping of tag identifiers to their name and description",
+      "propertyNames": {
+        "$ref": "#/definitions/TagIdentifier"
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/TagDefinition"
+      },
+      "maxProperties": 20,
+      "examples": [
+        {
+          "stablecoin": {
+            "name": "Stablecoin",
+            "description": "A token with value pegged to another asset"
+          }
+        }
+      ]
+    },
+    "logoURI": {
+      "type": "string",
+      "description": "A URI for the logo of the token list; prefer SVG or PNG of size 256x256",
+      "format": "uri",
+      "examples": ["ipfs://QmXfzKRvjZz3u5JRgC4v5mGVbm9ahrUiB4DgzHBsnWbTMM"]
+    }
+  },
+  "required": ["name", "timestamp", "version", "tokens"]
+}


### PR DESCRIPTION
Add token.schema.json and tokenlist.schema.json

`token.schema.json` has some hard-coded properties like Solana's token list.

The properties are:
```
website
twitter
discord
explorer
github
medium
tgann
tggroup
coingeckoId
address
assetContract
bridgeContract
imageUrl
description
```